### PR TITLE
Updated URL to download Siege 3.1.3

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-wget http://www.joedog.org/pub/siege/siege-3.0.2.tar.gz
-tar zxvf siege-3.0.2.tar.gz
-cd siege-3.0.2
+wget http://download.joedog.org/siege/siege-3.1.3.tar.gz
+tar zxvf siege-3.1.3.tar.gz
+cd siege-3.1.3
 ./configure
 make
 cd ..
-mv siege-3.0.2/src/siege .
-rm -rf siege-3.0.2
-rm -rf siege-3.0.2.tar.gz
+mv siege-3.1.3/src/siege .
+rm -rf siege-3.1.3
+rm -rf siege-3.1.3.tar.gz


### PR DESCRIPTION
Great repo!

I noticed small glitch.
The developer of Siege (joedog) has changed the download URL (old URL does no longer work).
Also I updated to use version Siege version 3.1.3 instead of 3.0.2.

Best regards
Wilhelm
